### PR TITLE
add MANIFEST.in to include required setup assets

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+recursive-include wmctrl *.c
+include COPYING
+include README.md
+include setup.py
+include setup.cfg


### PR DESCRIPTION
When installing from PyPI, an error like this cropped up:

```bash
$ pip install cwmctrl

Collecting cwmctrl
  Downloading https://files.pythonhosted.org/packages/07/53/32a06e44881c99cc288c039a72436bdbe0c201cdfcb4676506f814cd7bb2/cwmctrl-0.0.1.tar.gz
Building wheels for collected packages: cwmctrl
  Building wheel for cwmctrl (setup.py) ... error
  ...
  warning: Failed to find the configured license file 'COPYING'
  ...
  Copying cwmctrl.egg-info to build/bdist.linux-x86_64/wheel/cwmctrl-0.0.1-py3.7.egg-info
  running install_scripts
  error: [Errno 2] No such file or directory: 'COPYING'
  
  ----------------------------------------
  Failed building wheel for cwmctrl
  Running setup.py clean for cwmctrl
Failed to build cwmctrl
Installing collected packages: cwmctrl
  Running setup.py install for cwmctrl ... done
Successfully installed cwmctrl-0.0.1
```

Using a [`MANIFEST.in` template](https://docs.python.org/3.6/distutils/sourcedist.html#specifying-the-files-to-distribute), the `COPYING` file can be included in the source distribution, so PyPI installs look more like

```bash
$ pip install ./dist/cwmctrl-0.0.1.tar.gz 

Processing ./dist/cwmctrl-0.0.1.tar.gz
Building wheels for collected packages: cwmctrl
  Building wheel for cwmctrl (setup.py) ... done
  Stored in directory: /home/they4kman/.cache/pip/wheels/97/ec/b4/7d2f73e7badb0d0231d6eeb7bd56d7b2f506a9a216005581bb
Successfully built cwmctrl
Installing collected packages: cwmctrl
  Found existing installation: cwmctrl 0.0.1
    Uninstalling cwmctrl-0.0.1:
      Successfully uninstalled cwmctrl-0.0.1
Successfully installed cwmctrl-0.0.1
```