### PR TITLE
fix: link libX11 during build_ext

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,8 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 wmctrl_module = Extension('wmctrl',
-                           sources = ['wmctrl/wmctrlmodule.c'])
+                           sources = ['wmctrl/wmctrlmodule.c'],
+                           libraries = ['X11'])
 
 setup(
     name = 'cwmctrl',


### PR DESCRIPTION
Importing the `wmctrl` module gave me an "undefined symbol" ImportError
```ipy
In [1]: import wmctrl                                                                                                                                                                                
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-1-8c759e7e387b> in <module>
----> 1 import wmctrl

ImportError: /home/they4kman/.virtualenvs/yak/lib/python3.7/site-packages/wmctrl.cpython-37m-x86_64-linux-gnu.so: undefined symbol: XOpenDisplay
```

It seemed the `XOpenDisplay` comes from `libX11`, which wasn't linked.

This PR alters the `setup.py` to link `libX11` when building the extension.

```ipy
In [1]: import wmctrl                                                                                                                                                                                

In [2]: wmctrl.list_windows()                                                                                                                                                                        
Out[2]: 3
```